### PR TITLE
dystopia_slothbot: fix some warnings

### DIFF
--- a/[Dystopia]/[bots]/dystopia_slothbot/sbclient.lua
+++ b/[Dystopia]/[bots]/dystopia_slothbot/sbclient.lua
@@ -1313,19 +1313,23 @@ function panicCiviliansAround (theElement)
 	local Px,Py,Pz = getElementPosition( theElement )
 	local aipeds = getElementsByType ( "ped" )
 	for theKey,thePed in ipairs(aipeds) do
-			if ( getElementData ( thePed, "type" ) == "civilian" ) and (getElementData (thePed, "slothbot") ~= true) then
-				if getElementHealth(thePed)>0  then
-					local Ax,Ay,Az = getElementPosition( thePed )
-					local distance = (getDistanceBetweenPoints3D (Px, Py, Pz, Ax, Ay, Az))
-					if (distance < 30) then -- distance where where somebody triggers civilian panic around
-						if isElement(thePed) then setElementData(thePed,"panic",true,true) end
-						triggerEvent("sync.message", root, thePed, 255, 50, 0, "PANIC")
-						if isElement(thePed) then setTimer(setElementData,60000,1,thePed,"panic",false,true) end
-					end
+		if ( getElementData ( thePed, "type" ) == "civilian" ) and (getElementData (thePed, "slothbot") ~= true) then
+			if getElementHealth(thePed)>0  then
+				local Ax,Ay,Az = getElementPosition( thePed )
+				local distance = (getDistanceBetweenPoints3D (Px, Py, Pz, Ax, Ay, Az))
+				if (distance < 30) then -- distance where where somebody triggers civilian panic around
+					setElementData(thePed,"panic",true,true)
+					triggerEvent("sync.message", root, thePed, 255, 50, 0, "PANIC")
+					setTimer(
+						function()
+							if isElement(thePed) then
+								setElementData(thePed, "panic", false, true)
+							end
+						end, 60000, 1
+					)
 				end
 			end
-			
-		
+		end
 	end
 end
 

--- a/[Dystopia]/[bots]/dystopia_slothbot/sbserver.lua
+++ b/[Dystopia]/[bots]/dystopia_slothbot/sbserver.lua
@@ -119,7 +119,7 @@ function assigntarget ( player )
 		local foundTargetAnims = {"point_loop","shout_in"} 
 		setPedRotation(source,pedangle)
 		setPedAnimation(source,"ON_LOOKERS", table.random(foundTargetAnims),1500,false,true,true,false)
-		if isElement(source) then setTimer(function(pped) if isElement(pped) then setPedAnimation(pped)end end,1500,1,source) end
+		setTimer(function(pped) if isElement(pped) then setPedAnimation(pped)end end,1500,1,source)
 		local leped = source
 		triggerClientEvent(root, "sync.message", leped, leped, 240, 125, 0, "ALERT")
 		local rand1 = math.random(0,2)
@@ -138,12 +138,23 @@ function assigntarget ( player )
 				alertstable = regularAlertLines
 			end
 					
-			if not getElementData(source,"talking") and not isPedDead(source) then 
-			if isElement(source) then setTimer(triggerClientEvent,rand2,1,player,"onChatIncome", source,table.random(alertstable)); 
-			--sendNearbyPlayers(source,table.random(alertstable)) -- needs to be exported in dystopia_core
-			setElementData(source,"talking",true); 
-			end
-			if isElement(source) then setTimer(function(ped) if isElement(ped) then setElementData(ped,"talking",false) end end,3000+rand2,1,source) end
+			if not getElementData(source,"talking") and not isPedDead(source) then
+				setTimer(
+					function(source)
+						if isElement(source) then
+							triggerClientEvent(player,"onChatIncome", source,table.random(alertstable))
+						end
+					end, rand2, 1, source
+				)
+				--sendNearbyPlayers(source,table.random(alertstable)) -- needs to be exported in dystopia_core
+				setElementData(source,"talking",true);
+				setTimer(
+					function(ped)
+						if isElement(ped) then
+							setElementData(ped,"talking",false)
+						end
+					end,3000+rand2,1,source
+				)
 			end
 		end
 	end
@@ -298,7 +309,7 @@ function chase_move (ped, oldTx, oldTy, oldTz, oldPx, oldPy, oldPz)
 								if (weap == 1) or (weap == 7) then
 									setPedWeaponSlot(ped, 0 )
 									triggerClientEvent ( "bot_Jump", ped )
-									setTimer ( setPedWeaponSlot, 850, 1, ped, weap)
+									setTimer ( function () if isElement(ped) then setPedWeaponSlot(ped, weap) end end, 850, 1)
 								else
 									triggerClientEvent ( "bot_Jump", ped )
 								end
@@ -1222,56 +1233,107 @@ function spawnBot(x, y, z, rot, skin, interior, dimension, team, weapon, mode, m
 	if not skin then skin = 0 end
 	if not interior then interior = 0 end
 	if not dimension then dimension = 0 end
-	if isElement(team) == false then team = nil end
+	if not isElement(team) then team = nil end
 	if not weapon then weapon = 0 end
 	if not mode then mode = "hunting" end
 	if not modesubject then modesubject = nil end
 	if mode == "following" then
-		if not modesubject then return false end
+		if not modesubject then
+			return false
+		end
 	end
 	if mode == "chasing" then
-		if not modesubject then return false end
+		if not modesubject then
+			return false
+		end
 	end
-	local slothbot = createPed (tonumber(skin),tonumber(x),tonumber(y),tonumber(z))--spawns the ped
 	
-	local slothbotBackside = createColSphere(0,0,0,0.3) --ZZ
-	attachElements(slothbotBackside,slothbot,0,-1,0) --ZZ
-	setElementData(slothbot, "backSide", slothbotBackside,true) --ZZ
+	local slothbot = createPed(skin, x, y, z, rot) --spawns the ped
 	
-	if (slothbot ~= false) then
-		triggerEvent ( "onBotSpawned", slothbot )		
-		if isElement(slothbot) then setTimer ( setElementData, 200, 1, slothbot, "slothbot", true ) -- makes it a bot
-		setTimer ( setElementData, 200, 1, slothbot, "AllowFire", true ) -- makes it able to shoot when it wants
-		setTimer ( assigncontroller, 300, 1, slothbot ) --sets the bots controller
-		setTimer ( function () if isElement(slothbot) then giveWeapon(slothbot, tonumber(weapon), 99999, true) end end, 800, 1) --gives the weapon 
-		end
-		setElementData(slothbot, "BotWeapon", tonumber(weapon))
-		if team ~= nil then
-			setElementData(slothbot, "BotTeam", team)
-		end
-		if isElement(slothbot) then setTimer ( setElementInterior, 100, 1, slothbot, tonumber(interior)) --sets interior
-		setTimer ( setElementDimension, 100, 1, slothbot, tonumber(dimension)) --sets dimension
-		end
-		--sets the mode
-		if mode == "waiting" then
-			if isElement(slothbot) then setTimer ( setElementData, 600, 1, slothbot, "status", "waiting") end
-		elseif mode == "following" then
+	local slothbotBackside = createColSphere(0, 0, 0, 0.3) --ZZ
+	attachElements(slothbotBackside, slothbot, 0, -1, 0) --ZZ
+	setElementData(slothbot, "backSide", slothbotBackside, true) --ZZ
+	
+	triggerEvent("onBotSpawned", slothbot)
+	
+	setTimer(
+		function()
 			if isElement(slothbot) then
-			setTimer ( setElementData, 400, 1, slothbot, "leader", modesubject )
-			setTimer ( setElementData, 600, 1, slothbot, "status", "following")
+				setElementData(slothbot, "slothbot", true) -- makes it a bot
+				setElementData(slothbot, "AllowFire", true) -- makes it able to shoot when it wants
 			end
-		elseif mode == "chasing" then
+		end, 200, 1
+	)
+	
+	setTimer(
+		function()
 			if isElement(slothbot) then
-			setTimer ( setElementData, 400, 1, slothbot, "target", modesubject )
-			setTimer ( setElementData, 600, 1, slothbot, "status", "chasing")
+				assigncontroller(slothbot) --sets the bots controller
 			end
-		elseif mode == "guarding" then
-			if isElement(slothbot) then setTimer ( setBotGuard, 400, 1, slothbot, x, y, z) end
-		else
-			if isElement(slothbot) then setTimer ( function(slothbot) if isElement(slothbot) then setElementData(slothbot, "status", "hunting") end end, 600, 1, slothbot) end
-		end
-		return slothbot
+		end, 300, 1
+	)
+	
+	setTimer(
+		function()
+			if isElement(slothbot) then
+				giveWeapon(slothbot, weapon, 99999, true) --gives the weapon
+			end
+		end, 800, 1
+	)
+	
+	setElementData(slothbot, "BotWeapon", weapon)
+	
+	if team then
+		setElementData(slothbot, "BotTeam", team)
 	end
+	
+	setTimer(
+		function()
+			if isElement(slothbot) then
+				setElementInterior(slothbot, interior) --sets interior
+				setElementDimension(slothbot, dimension) --sets dimension
+			end
+		end, 100, 1
+	)
+	
+	--sets the mode
+	if mode ~= "guarding" then
+		setTimer(
+			function()
+				if isElement(slothbot) then
+					setElementData(slothbot, "status", mode)
+				end
+			end, 600, 1
+		)
+	end
+	
+	if mode == "following" then
+		setTimer(
+			function()
+				if isElement(slothbot) then
+					setElementData(slothbot, "leader", modesubject)
+				end
+			end, 400, 1
+		)
+	elseif mode == "chasing" then
+		setTimer(
+			function()
+				if isElement(slothbot) then
+					setElementData(slothbot, "target", modesubject)
+				end
+			end, 400, 1
+		)
+	elseif mode == "guarding" then
+		setTimer(
+			function()
+				if isElement(slothbot) then
+					setBotGuard(slothbot, x, y, z)
+				end
+			end, 400, 1
+		)
+	end
+	
+	return slothbot
 end
 
 function setBotTeam(ped, team)


### PR DESCRIPTION
This PR fixes some warnings in dystopia_slothbot resource. Maybe a better solution would be to get rid of timers in some places (e.g. in spawnBot function), but this may lead to unknown results and need more time for tests.